### PR TITLE
Removed orphaned `service` variable in s3 impl.

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -23,16 +23,12 @@ type Config struct {
 	Bucket string
 }
 
-var service s3iface.S3API
-
 func New(c Config) (gost.Directory, error) {
-	if service == nil {
-		sess, _ := session.NewSession(&aws.Config{
-			Region:      aws.String(c.Region),
-			Credentials: credentials.NewStaticCredentials(c.Id, c.Secret, c.Token),
-		})
-		service = s3.New(sess)
-	}
+	sess, _ := session.NewSession(&aws.Config{
+		Region:      aws.String(c.Region),
+		Credentials: credentials.NewStaticCredentials(c.Id, c.Secret, c.Token),
+	})
+	service := s3.New(sess)
 
 	fs := Filesystem{
 		Service: service,
@@ -49,8 +45,4 @@ func New(c Config) (gost.Directory, error) {
 	}
 
 	return rootDir, nil
-}
-
-func SetService(s s3iface.S3API) {
-	service = s
 }

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -1,7 +1,7 @@
 package s3
 
 import (
-	"errors"
+	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -34,7 +34,7 @@ func New(c Config) (gost.Directory, error) {
 			Region:      aws.String(c.Region),
 			Credentials: credentials.NewStaticCredentials(c.Id, c.Secret, c.Token),
 		})
-		c.S3 = s3.New(sess)
+		svc = s3.New(sess)
 	}
 
 	fs := Filesystem{

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -20,8 +20,6 @@ var s3mock mocks.S3API
 
 func init() {
 	s3mock = mocks.S3API{}
-	SetService(&s3mock)
-
 	setMockExpectations()
 
 	s3fs, _ = New(Config{
@@ -29,6 +27,7 @@ func init() {
 		Region: "eu-west-1",
 		Id:     "aws_access_id",
 		Secret: "aws_secret_id",
+		S3:     &s3mock,
 	})
 
 }


### PR DESCRIPTION
For our project, we need to query s3 buckets from different regions/accounts. The current implementation of `gost` initializes aws-s3 and sets it to a local `service` variable. When `New()` is called again, with a different `config` params, the already initialized service variable is reused. This is causing problems when we create a gost fs against s3 in different regions.

It seems like the local `service` variable and `SetService` isn't being used anywhere else.