### PR TITLE
fix(s3): deprecated global service and introduced local service definition to allow working with multiple regions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
   allow_failures:
     - go: tip
 
+env:
+  - GO111MODULE=on
+
 install:
   - go get -t -v ./...
   - go get github.com/mattn/goveralls

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -23,9 +23,14 @@ type Config struct {
 	Bucket string
 }
 
-var service s3iface.S3API
+var globalService s3iface.S3API
 
-func New(c Config) (gost.Directory, error) {
+func New(c Config, service s3iface.S3API) (gost.Directory, error) {
+	// service always takes priority over globalService
+	if globalService != nil && service == nil {
+		service = globalService
+	}
+
 	if service == nil {
 		sess, _ := session.NewSession(&aws.Config{
 			Region:      aws.String(c.Region),
@@ -51,6 +56,7 @@ func New(c Config) (gost.Directory, error) {
 	return rootDir, nil
 }
 
+// Deprecated: SetService will be removed in the next major release
 func SetService(s s3iface.S3API) {
-	service = s
+	globalService = s
 }

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -25,7 +25,12 @@ type Config struct {
 
 var globalService s3iface.S3API
 
-func New(c Config, service s3iface.S3API) (gost.Directory, error) {
+func New(c Config, services ...s3iface.S3API) (gost.Directory, error) {
+	var service s3iface.S3API
+	if len(services) > 0 {
+		service = services[0]
+	}
+
 	// service always takes priority over globalService
 	if globalService != nil && service == nil {
 		service = globalService

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -29,7 +29,7 @@ func init() {
 		Region: "eu-west-1",
 		Id:     "aws_access_id",
 		Secret: "aws_secret_id",
-	})
+	}, nil)
 
 }
 


### PR DESCRIPTION
Updated the `New` function in S3 interface:

`func New(c Config, services ...s3iface.S3API) ...`

The global service is now changed to globalService, and will only be used if the service arg in New is nil.

This will allow us to work with multiple buckets across multiple regions and AWS accounts